### PR TITLE
Update pwdpolicies-contents.tex

### DIFF
--- a/pwdpolicies/pwdpolicies-contents.tex
+++ b/pwdpolicies/pwdpolicies-contents.tex
@@ -2,7 +2,7 @@
 \subtitle{Designing a secure and usable password policy}
 
 \author{%
-  Daniel Bosk
+  Daniel Bosk \and Lennart Franked
 }
 \institute{%
   Department of Information and Communication Systems\\
@@ -10,7 +10,6 @@
 }
 
 \maketitle
-
 
 \section{Introduction}
 \label{sec:intro}
@@ -39,11 +38,9 @@ assignment and how to do the work.
 \Cref{sec:exam} covers how it will be examined, i.e.~how you show that you have 
 fulfilled the intended learning outcomes given above.
 
-
 \section{Theory}
 \label{sec:theory}
 \input{literature.tex}
-
 
 \section{Assignment}
 \label{sec:tasks}
@@ -55,27 +52,30 @@ Let these questions guide your reading:
   \item How did they conclude them?
 \end{itemize}
 
-During the seminar we will discuss your thoughts, the results of the research 
-papers, we will also discuss password-composition policies in general.
 After reading and reflection, think about the following questions:
+
 \begin{itemize}
   \item What is your strategy for remembering passwords?
   \item How do you react to different password policies?
   \item Is it fine to write down passwords or not?
+  \item In the situation where you have forgotten you password,
+  	what kind of password recovery schemes have you encountered?
+  \item What is your reaction towards the different password recovery schemes? 
 \end{itemize}
 
 Finally, look at the University's password-composition policy, what do you 
-think is the reasoning behind this?
+think is the reasoning behind this? What are the strengths and weaknesses of this policy?
 
+During the seminar we will discuss your thoughts, the results of the research 
+papers. You will later be divided into groups, and be given some exercises
+regarding password-composition policies. The group excerice will finish with each group
+briefly presenting their result.
 
 \section{Examination}
 \label{sec:exam}
 To pass this assignment you need to actively participate in the seminar.
 
-
 \subsubsection*{Acknowledements}
-
-This work was reviewed and improved by Lennart Franked, Mid Sweden Uiversity.
 
 This work is released under the Creative Commons Attribution-ShareAlike 3.0 
 Unported license.
@@ -83,6 +83,5 @@ To view a copy of this license, visit
 \url{http://creativecommons.org/licenses/by-sa/3.0/}.
 You can find the original source code in URL 
 \url{https://github.com/dbosk/passwd/pwdguess/}.
-
 
 \printbibliography{}


### PR DESCRIPTION
Lade till ämnet password-recovery då jag tycker detta är lika aktuellt som utforming av lösenord.

Utökade utförande genom att lägga till att en gruppuppgift kommer utföras, då vi inte bestämt ännu exakt vad denna gruppuppgift skall innefatta lät jag den vara vagt formulerad. Vi kan på detta sätt ge en typ av uppgift till distansstudenterna och en annan till campus (på grund utav olika bakgrunder, nivåer och undervisningsformat)

Tog mig även frihet att lägga till mig själv som "second author" och plockade bort mig från acknowledgement.
